### PR TITLE
Fix variables in some makefiles

### DIFF
--- a/Makefile.demo
+++ b/Makefile.demo
@@ -36,18 +36,18 @@ SOURCES+=src/synth/noise.cpp
 SOURCES+=src/synth/synthesizer.cpp
 
 ifeq ($(DEBUG),YES)
-    CFLAGS+=-g -O0
+    CXXFLAGS+=-g -O0
 else
-    CFLAGS+=-O3
+    CXXFLAGS+=-O3
 endif
 
 ifeq ($(PROFILING),YES)
-    CFLAGS+=-D__RENDER_TO_MEMORY__ONLY__
-    #CFLAGS+=-nostdlib
+    CXXFLAGS+=-D__RENDER_TO_MEMORY__ONLY__
+    #CXXFLAGS+=-nostdlib
 endif
 
 ifeq ($(WITH_DSOUND),YES)
-    CFLAGS+=-D__WITH_DSOUND__
+    CXXFLAGS+=-D__WITH_DSOUND__
     LDFLAGS+=-ldsound
 endif
 
@@ -69,7 +69,7 @@ else
 endif
 
 all:
-	@$(CXX) -o $(EXECUTABLE_NAME) -DEXECUTABLE_NAME=\"$(EXECUTABLE_NAME)\" -D__OXEDMO__ $(CFLAGS) $(SOURCES) $(INCLUDES) $(LDFLAGS)
+	@$(CXX) -o $(EXECUTABLE_NAME) -DEXECUTABLE_NAME=\"$(EXECUTABLE_NAME)\" -D__OXEDMO__ $(CXXFLAGS) $(SOURCES) $(INCLUDES) $(LDFLAGS)
 
 clean:
 	@rm -f $(EXECUTABLE_NAME) *.wav

--- a/Makefile.standalone
+++ b/Makefile.standalone
@@ -45,9 +45,9 @@ SOURCES+=src/synth/synthesizer.cpp
 UNAME_S:=$(shell uname -s)
 
 ifeq ($(DEBUG),YES)
-    CFLAGS+=-g -O0
+    CXXFLAGS+=-g -O0
 else
-    CFLAGS+=-O3
+    CXXFLAGS+=-O3
     ifneq ($(UNAME_S),Darwin)
         LDFLAGS+=-s
     endif
@@ -90,7 +90,7 @@ else
             LDFLAGS+=-lpthread
             LDFLAGS+=-ldl
             ifeq ($(USE_OPENGL),YES)
-                CFLAGS+=-DUSE_OPENGL
+                CXXFLAGS+=-DUSE_OPENGL
                 LDFLAGS+=-lGL
                 SOURCES+=src/toolkits/opengltoolkit.cpp
             endif
@@ -100,7 +100,7 @@ else
 endif
 
 all: $(DEPS)
-	@$(CXX) -o $(EXECUTABLE_NAME) -DEXECUTABLE_NAME=\"$(EXECUTABLE_NAME)\" $(CFLAGS) $(SOURCES) $(INCLUDES) $(LDFLAGS)
+	@$(CXX) -o $(EXECUTABLE_NAME) -DEXECUTABLE_NAME=\"$(EXECUTABLE_NAME)\" $(CXXFLAGS) $(SOURCES) $(INCLUDES) $(LDFLAGS)
 	@$(CMD)
 ifeq ($(UNAME_S),Darwin)
 	@mkdir -p $(EXECUTABLE_NAME).app/Contents/MacOS
@@ -109,12 +109,12 @@ ifeq ($(UNAME_S),Darwin)
 endif
 
 bitmaps.cpp:
-	@$(CXX) -o embedresources src/toolkits/embedresources.cpp
+	@$(CXX) -o embedresources $(CXXFLAGS) src/toolkits/embedresources.cpp
 	@./embedresources $@
 	@rm embedresources
 
 cocoatoolkit.o:
-	@gcc -c -o $@ $(OBJCSOURCES) $(INCLUDES) $(OBJCFLAGS)
+	@gcc -c -o $@ $(OBJCSOURCES) $(INCLUDES) $(OBJCXXFLAGS)
 
 resources.o:
 	@$(RC) -Isrc/synth -Iskins/default src/windows/resources.rc resources.o

--- a/Makefile.vstlinux
+++ b/Makefile.vstlinux
@@ -57,12 +57,12 @@ LIBS:=-lX11
 LIBS+=-lpthread
 LIBS+=-ldl
 
-CFLAGS+=-fPIC -D__cdecl=
+CXXFLAGS+=-fPIC -D__cdecl=
 
 ifeq ($(DEBUG),YES)
-    CFLAGS+=-g -O0
+    CXXFLAGS+=-g -O0
 else
-    CFLAGS+=-s -O3
+    CXXFLAGS+=-s -O3
 endif
 
 ARCH := $(shell getconf LONG_BIT)
@@ -73,13 +73,13 @@ endif
 all: oxevst$(ARCH)
 
 oxevst32: bitmaps.cpp
-	@$(CXX) -shared $(BITS) -o oxevst32.so $(CFLAGS) $(SOURCES) $(INCLUDES) $(LIBS)
+	@$(CXX) -shared $(BITS) -o oxevst32.so $(CXXFLAGS) $(SOURCES) $(INCLUDES) $(LIBS) $(LDFLAGS)
 
 oxevst64: bitmaps.cpp
-	@$(CXX) -shared -m64    -o oxevst64.so $(CFLAGS) $(SOURCES) $(INCLUDES) $(LIBS)
+	@$(CXX) -shared -m64    -o oxevst64.so $(CXXFLAGS) $(SOURCES) $(INCLUDES) $(LIBS) $(LDFLAGS)
 
 bitmaps.cpp:
-	@$(CXX) -o embedresources src/toolkits/embedresources.cpp
+	@$(CXX) -o embedresources src/toolkits/embedresources.cpp $(CXXFLAGS)
 	@./embedresources $@
 	@rm embedresources
 


### PR DESCRIPTION
CFLAGS was wrongly misused, should be CXXFLAGS for C++ code.
CXXFLAGS was missing when building resources
LDFLAGS missing when building the vst plugin