### PR TITLE
GUI scaling

### DIFF
--- a/src/gui/button.cpp
+++ b/src/gui/button.cpp
@@ -22,8 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "control.h"
 #include "button.h"
 
-#define BUTTON_WIDTH   42
-#define BUTTON_HEIGHT  16
+#define BUTTON_WIDTH   (42*GUI_SCALE)
+#define BUTTON_HEIGHT  (16*GUI_SCALE)
 
 CButton::CButton(int bmp, int index, CSynthesizer *synthesizer, char &channel, int type, int x, int y)
 {

--- a/src/gui/channels.cpp
+++ b/src/gui/channels.cpp
@@ -22,8 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "control.h"
 #include "channels.h"
 
-#define KEY_WIDTH   10
-#define KEY_HEIGHT  10
+#define KEY_WIDTH   10*GUI_SCALE
+#define KEY_HEIGHT  10*GUI_SCALE
 
 CChannels::CChannels(int bmp, CSynthesizer *synthesizer, char &channel, int x, int y)
 {

--- a/src/gui/editor.cpp
+++ b/src/gui/editor.cpp
@@ -35,294 +35,294 @@ CEditor::CEditor(CSynthesizer *synthesizer)
     int aY   = 0;
 
     // separation between the operators controls
-    int sX   = 32;
+    int sX   = 32*GUI_SCALE;
     int sX2  = sX/2;
-    int sY   = 35;
+    int sY   = 35*GUI_SCALE;
 
     // separation between the operators
-    int oX   = 202;
-    int oY   = 94;
+    int oX   = 202*GUI_SCALE;
+    int oY   = 94*GUI_SCALE;
 
     // separation between the half matrix controls
-    int fX   = 20;
-    int fY   = 20;
+    int fX   = 20*GUI_SCALE;
+    int fY   = 20*GUI_SCALE;
 
     // separation between the buttons
-    int tX   = 44;
-    int tY   = 16;
+    int tX   = 44*GUI_SCALE;
+    int tY   = 16*GUI_SCALE;
 
     // OPA coordinates
-    int cX   = 17;
-    int cY   = 80;
+    int cX   = 17*GUI_SCALE;
+    int cY   = 80*GUI_SCALE;
 
     // half-matrix coordinates
-    int mX   = 419;
-    int mY   = 77;
+    int mX   = 419*GUI_SCALE;
+    int mY   = 77*GUI_SCALE;
 
     // LFO section coordinates
-    int lX   = 421;
-    int lY   = 338;
+    int lX   = 421*GUI_SCALE;
+    int lY   = 338*GUI_SCALE;
 
     // pitch section coordinates
-    int pX   = 421;
-    int pY   = 397;
+    int pX   = 421*GUI_SCALE;
+    int pY   = 397*GUI_SCALE;
 
     // effects section coordinates
-    int zX   = 527;
-    int zY   = 397;
+    int zX   = 527*GUI_SCALE;
+    int zY   = 397*GUI_SCALE;
 
     // modulation control coordinates
-    int dX   = 591;
-    int dY   = 338;
+    int dX   = 591*GUI_SCALE;
+    int dY   = 338*GUI_SCALE;
 
     // channels control coordinates
-    int gX   = 327;
-    int gY   = 25;
+    int gX   = 327*GUI_SCALE;
+    int gY   = 25*GUI_SCALE;
 
     // reverb section corrdinates
-    int rX   = 559;
-    int rY   = 23;
+    int rX   = 559*GUI_SCALE;
+    int rY   = 23*GUI_SCALE;
 
     // delay section coordinates
-    int eX   = 421;
-    int eY   = 23;
+    int eX   = 421*GUI_SCALE;
+    int eY   = 23*GUI_SCALE;
 
     // buttons section coordinates
-    int bX   = 147;
-    int bY   = 15;
+    int bX   = 147*GUI_SCALE;
+    int bY   = 15*GUI_SCALE;
 
     // hq control coordinates
-    int hX   = 603;
-    int hY   = 401;
+    int hX   = 603*GUI_SCALE;
+    int hY   = 401*GUI_SCALE;
 
     // display
-    lcd             = new CLcd     (BMP_CHARS, 25, 23);
+    lcd             = new CLcd     (BMP_CHARS, 25*GUI_SCALE, 23*GUI_SCALE);
 
     // OPA
     aX = cX;
     aY = cY;
-    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10,10,"OPA On/Off",      synthesizer, channel,                   OPAON, aX         , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPA Waveform",    synthesizer, channel, VL_WAVEFORM,      OPAWF, aX+sX2     , aY      );
-    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10,10,"OPA Keyb Track",  synthesizer, channel,                   OPAKT, aX+sX+sX2  , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPA Coarse Tune", synthesizer, channel, VL_COARSE_TUNE,   OPACT, aX+sX*2    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPA Fine Tune",   synthesizer, channel, VL_FINE_TUNE,     OPAFT, aX+sX*3    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPA VlSensivity", synthesizer, channel, VL_ZERO_TO_ONE,   OPAVS, aX+sX*4    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPA KeybScaling", synthesizer, channel, VL_MINUS1_2_PLUS1,OPAKS, aX+sX*5    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPA Delay Time",  synthesizer, channel, VL_PORTAMENTO,    OPADL, aX         , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPA Attack Time", synthesizer, channel, VL_TEMPO,         OPAAT, aX+sX      , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPA Decay Time",  synthesizer, channel, VL_TEMPO,         OPADE, aX+sX*2    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPA Sustain Lvl", synthesizer, channel, VL_ZERO_TO_ONE,   OPASU, aX+sX*3    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPA SustainTime", synthesizer, channel, VL_PORTAMENTO,    OPAST, aX+sX*4    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPA ReleaseTime", synthesizer, channel, VL_TEMPO,         OPARE, aX+sX*5    , aY+sY   );
+    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10*GUI_SCALE,10*GUI_SCALE,"OPA On/Off",      synthesizer, channel,                   OPAON, aX         , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPA Waveform",    synthesizer, channel, VL_WAVEFORM,      OPAWF, aX+sX2     , aY      );
+    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10*GUI_SCALE,10*GUI_SCALE,"OPA Keyb Track",  synthesizer, channel,                   OPAKT, aX+sX+sX2  , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPA Coarse Tune", synthesizer, channel, VL_COARSE_TUNE,   OPACT, aX+sX*2    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPA Fine Tune",   synthesizer, channel, VL_FINE_TUNE,     OPAFT, aX+sX*3    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPA VlSensivity", synthesizer, channel, VL_ZERO_TO_ONE,   OPAVS, aX+sX*4    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPA KeybScaling", synthesizer, channel, VL_MINUS1_2_PLUS1,OPAKS, aX+sX*5    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPA Delay Time",  synthesizer, channel, VL_PORTAMENTO,    OPADL, aX         , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPA Attack Time", synthesizer, channel, VL_TEMPO,         OPAAT, aX+sX      , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPA Decay Time",  synthesizer, channel, VL_TEMPO,         OPADE, aX+sX*2    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPA Sustain Lvl", synthesizer, channel, VL_ZERO_TO_ONE,   OPASU, aX+sX*3    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPA SustainTime", synthesizer, channel, VL_PORTAMENTO,    OPAST, aX+sX*4    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPA ReleaseTime", synthesizer, channel, VL_TEMPO,         OPARE, aX+sX*5    , aY+sY   );
 
     // OPB
     aX = cX + oX;
     aY = cY;
-    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10,10,"OPB On/Off",      synthesizer, channel,                   OPBON, aX         , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPB Waveform",    synthesizer, channel, VL_WAVEFORM,      OPBWF, aX+sX2     , aY      );
-    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10,10,"OPB Keyb Track",  synthesizer, channel,                   OPBKT, aX+sX+sX2  , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPB Coarse Tune", synthesizer, channel, VL_COARSE_TUNE,   OPBCT, aX+sX*2    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPB Fine Tune",   synthesizer, channel, VL_FINE_TUNE,     OPBFT, aX+sX*3    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPB VlSensivity", synthesizer, channel, VL_ZERO_TO_ONE,   OPBVS, aX+sX*4    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPB KeybScaling", synthesizer, channel, VL_MINUS1_2_PLUS1,OPBKS, aX+sX*5    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPB Delay Time",  synthesizer, channel, VL_PORTAMENTO,    OPBDL, aX         , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPB Attack Time", synthesizer, channel, VL_TEMPO,         OPBAT, aX+sX      , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPB Decay Time",  synthesizer, channel, VL_TEMPO,         OPBDE, aX+sX*2    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPB Sustain Lvl", synthesizer, channel, VL_ZERO_TO_ONE,   OPBSU, aX+sX*3    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPB SustainTime", synthesizer, channel, VL_PORTAMENTO,    OPBST, aX+sX*4    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPB ReleaseTime", synthesizer, channel, VL_TEMPO,         OPBRE, aX+sX*5    , aY+sY   );
+    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10*GUI_SCALE,10*GUI_SCALE,"OPB On/Off",      synthesizer, channel,                   OPBON, aX         , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPB Waveform",    synthesizer, channel, VL_WAVEFORM,      OPBWF, aX+sX2     , aY      );
+    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10*GUI_SCALE,10*GUI_SCALE,"OPB Keyb Track",  synthesizer, channel,                   OPBKT, aX+sX+sX2  , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPB Coarse Tune", synthesizer, channel, VL_COARSE_TUNE,   OPBCT, aX+sX*2    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPB Fine Tune",   synthesizer, channel, VL_FINE_TUNE,     OPBFT, aX+sX*3    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPB VlSensivity", synthesizer, channel, VL_ZERO_TO_ONE,   OPBVS, aX+sX*4    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPB KeybScaling", synthesizer, channel, VL_MINUS1_2_PLUS1,OPBKS, aX+sX*5    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPB Delay Time",  synthesizer, channel, VL_PORTAMENTO,    OPBDL, aX         , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPB Attack Time", synthesizer, channel, VL_TEMPO,         OPBAT, aX+sX      , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPB Decay Time",  synthesizer, channel, VL_TEMPO,         OPBDE, aX+sX*2    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPB Sustain Lvl", synthesizer, channel, VL_ZERO_TO_ONE,   OPBSU, aX+sX*3    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPB SustainTime", synthesizer, channel, VL_PORTAMENTO,    OPBST, aX+sX*4    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPB ReleaseTime", synthesizer, channel, VL_TEMPO,         OPBRE, aX+sX*5    , aY+sY   );
 
     // OPC
     aX = cX;
     aY = cY + oY;
-    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10,10,"OPC On/Off",      synthesizer, channel,                   OPCON, aX         , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPC Waveform",    synthesizer, channel, VL_WAVEFORM,      OPCWF, aX+sX2     , aY      );
-    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10,10,"OPC Keyb Track",  synthesizer, channel,                   OPCKT, aX+sX+sX2  , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPC Coarse Tune", synthesizer, channel, VL_COARSE_TUNE,   OPCCT, aX+sX*2    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPC Fine Tune",   synthesizer, channel, VL_FINE_TUNE,     OPCFT, aX+sX*3    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPC VlSensivity", synthesizer, channel, VL_ZERO_TO_ONE,   OPCVS, aX+sX*4    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPC KeybScaling", synthesizer, channel, VL_MINUS1_2_PLUS1,OPCKS, aX+sX*5    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPC Delay Time",  synthesizer, channel, VL_PORTAMENTO,    OPCDL, aX         , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPC Attack Time", synthesizer, channel, VL_TEMPO,         OPCAT, aX+sX      , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPC Decay Time",  synthesizer, channel, VL_TEMPO,         OPCDE, aX+sX*2    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPC Sustain Lvl", synthesizer, channel, VL_ZERO_TO_ONE,   OPCSU, aX+sX*3    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPC SustainTime", synthesizer, channel, VL_PORTAMENTO,    OPCST, aX+sX*4    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPC ReleaseTime", synthesizer, channel, VL_TEMPO,         OPCRE, aX+sX*5    , aY+sY   );
+    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10*GUI_SCALE,10*GUI_SCALE,"OPC On/Off",      synthesizer, channel,                   OPCON, aX         , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPC Waveform",    synthesizer, channel, VL_WAVEFORM,      OPCWF, aX+sX2     , aY      );
+    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10*GUI_SCALE,10*GUI_SCALE,"OPC Keyb Track",  synthesizer, channel,                   OPCKT, aX+sX+sX2  , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPC Coarse Tune", synthesizer, channel, VL_COARSE_TUNE,   OPCCT, aX+sX*2    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPC Fine Tune",   synthesizer, channel, VL_FINE_TUNE,     OPCFT, aX+sX*3    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPC VlSensivity", synthesizer, channel, VL_ZERO_TO_ONE,   OPCVS, aX+sX*4    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPC KeybScaling", synthesizer, channel, VL_MINUS1_2_PLUS1,OPCKS, aX+sX*5    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPC Delay Time",  synthesizer, channel, VL_PORTAMENTO,    OPCDL, aX         , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPC Attack Time", synthesizer, channel, VL_TEMPO,         OPCAT, aX+sX      , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPC Decay Time",  synthesizer, channel, VL_TEMPO,         OPCDE, aX+sX*2    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPC Sustain Lvl", synthesizer, channel, VL_ZERO_TO_ONE,   OPCSU, aX+sX*3    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPC SustainTime", synthesizer, channel, VL_PORTAMENTO,    OPCST, aX+sX*4    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPC ReleaseTime", synthesizer, channel, VL_TEMPO,         OPCRE, aX+sX*5    , aY+sY   );
 
     // OPD
     aX = cX + oX;
     aY = cY + oY;
-    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10,10,"OPD On/Off",      synthesizer, channel,                   OPDON, aX         , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPD Waveform",    synthesizer, channel, VL_WAVEFORM,      OPDWF, aX+sX2     , aY      );
-    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10,10,"OPD Keyb Track",  synthesizer, channel,                   OPDKT, aX+sX+sX2  , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPD Coarse Tune", synthesizer, channel, VL_COARSE_TUNE,   OPDCT, aX+sX*2    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPD Fine Tune",   synthesizer, channel, VL_FINE_TUNE,     OPDFT, aX+sX*3    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPD VlSensivity", synthesizer, channel, VL_ZERO_TO_ONE,   OPDVS, aX+sX*4    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPD KeybScaling", synthesizer, channel, VL_MINUS1_2_PLUS1,OPDKS, aX+sX*5    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPD Delay Time",  synthesizer, channel, VL_PORTAMENTO,    OPDDL, aX         , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPD Attack Time", synthesizer, channel, VL_TEMPO,         OPDAT, aX+sX      , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPD Decay Time",  synthesizer, channel, VL_TEMPO,         OPDDE, aX+sX*2    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPD Sustain Lvl", synthesizer, channel, VL_ZERO_TO_ONE,   OPDSU, aX+sX*3    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPD SustainTime", synthesizer, channel, VL_PORTAMENTO,    OPDST, aX+sX*4    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPD ReleaseTime", synthesizer, channel, VL_TEMPO,         OPDRE, aX+sX*5    , aY+sY   );
+    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10*GUI_SCALE,10*GUI_SCALE,"OPD On/Off",      synthesizer, channel,                   OPDON, aX         , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPD Waveform",    synthesizer, channel, VL_WAVEFORM,      OPDWF, aX+sX2     , aY      );
+    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10*GUI_SCALE,10*GUI_SCALE,"OPD Keyb Track",  synthesizer, channel,                   OPDKT, aX+sX+sX2  , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPD Coarse Tune", synthesizer, channel, VL_COARSE_TUNE,   OPDCT, aX+sX*2    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPD Fine Tune",   synthesizer, channel, VL_FINE_TUNE,     OPDFT, aX+sX*3    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPD VlSensivity", synthesizer, channel, VL_ZERO_TO_ONE,   OPDVS, aX+sX*4    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPD KeybScaling", synthesizer, channel, VL_MINUS1_2_PLUS1,OPDKS, aX+sX*5    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPD Delay Time",  synthesizer, channel, VL_PORTAMENTO,    OPDDL, aX         , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPD Attack Time", synthesizer, channel, VL_TEMPO,         OPDAT, aX+sX      , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPD Decay Time",  synthesizer, channel, VL_TEMPO,         OPDDE, aX+sX*2    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPD Sustain Lvl", synthesizer, channel, VL_ZERO_TO_ONE,   OPDSU, aX+sX*3    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPD SustainTime", synthesizer, channel, VL_PORTAMENTO,    OPDST, aX+sX*4    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPD ReleaseTime", synthesizer, channel, VL_TEMPO,         OPDRE, aX+sX*5    , aY+sY   );
 
     // OPE
     aX = cX;
     aY = cY + oY * 2;
-    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10,10,"OPE On/Off",      synthesizer, channel,                   OPEON, aX         , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPE Waveform",    synthesizer, channel, VL_WAVEFORM,      OPEWF, aX+sX2     , aY      );
-    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10,10,"OPE Keyb Track",  synthesizer, channel,                   OPEKT, aX+sX+sX2  , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPE Coarse Tune", synthesizer, channel, VL_COARSE_TUNE,   OPECT, aX+sX*2    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPE Fine Tune",   synthesizer, channel, VL_FINE_TUNE,     OPEFT, aX+sX*3    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPE VlSensivity", synthesizer, channel, VL_ZERO_TO_ONE,   OPEVS, aX+sX*4    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPE KeybScaling", synthesizer, channel, VL_MINUS1_2_PLUS1,OPEKS, aX+sX*5    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPE Delay Time",  synthesizer, channel, VL_PORTAMENTO,    OPEDL, aX         , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPE Attack Time", synthesizer, channel, VL_TEMPO,         OPEAT, aX+sX      , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPE Decay Time",  synthesizer, channel, VL_TEMPO,         OPEDE, aX+sX*2    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPE Sustain Lvl", synthesizer, channel, VL_ZERO_TO_ONE,   OPESU, aX+sX*3    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPE SustainTime", synthesizer, channel, VL_PORTAMENTO,    OPEST, aX+sX*4    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPE ReleaseTime", synthesizer, channel, VL_TEMPO,         OPERE, aX+sX*5    , aY+sY   );
+    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10*GUI_SCALE,10*GUI_SCALE,"OPE On/Off",      synthesizer, channel,                   OPEON, aX         , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPE Waveform",    synthesizer, channel, VL_WAVEFORM,      OPEWF, aX+sX2     , aY      );
+    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10*GUI_SCALE,10*GUI_SCALE,"OPE Keyb Track",  synthesizer, channel,                   OPEKT, aX+sX+sX2  , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPE Coarse Tune", synthesizer, channel, VL_COARSE_TUNE,   OPECT, aX+sX*2    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPE Fine Tune",   synthesizer, channel, VL_FINE_TUNE,     OPEFT, aX+sX*3    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPE VlSensivity", synthesizer, channel, VL_ZERO_TO_ONE,   OPEVS, aX+sX*4    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPE KeybScaling", synthesizer, channel, VL_MINUS1_2_PLUS1,OPEKS, aX+sX*5    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPE Delay Time",  synthesizer, channel, VL_PORTAMENTO,    OPEDL, aX         , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPE Attack Time", synthesizer, channel, VL_TEMPO,         OPEAT, aX+sX      , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPE Decay Time",  synthesizer, channel, VL_TEMPO,         OPEDE, aX+sX*2    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPE Sustain Lvl", synthesizer, channel, VL_ZERO_TO_ONE,   OPESU, aX+sX*3    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPE SustainTime", synthesizer, channel, VL_PORTAMENTO,    OPEST, aX+sX*4    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPE ReleaseTime", synthesizer, channel, VL_TEMPO,         OPERE, aX+sX*5    , aY+sY   );
 
     // OPF
     aX = cX + oX;
     aY = cY + oY * 2;
-    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10,10,"OPF On/Off",      synthesizer, channel,                   OPFON, aX         , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPF Waveform",    synthesizer, channel, VL_WAVEFORM,      OPFWF, aX+sX2     , aY      );
-    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10,10,"OPF Keyb Track",  synthesizer, channel,                   OPFKT, aX+sX+sX2  , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPF Coarse Tune", synthesizer, channel, VL_COARSE_TUNE,   OPFCT, aX+sX*2    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPF Fine Tune",   synthesizer, channel, VL_FINE_TUNE,     OPFFT, aX+sX*3    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPF VlSensivity", synthesizer, channel, VL_ZERO_TO_ONE,   OPFVS, aX+sX*4    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPF KeybScaling", synthesizer, channel, VL_MINUS1_2_PLUS1,OPFKS, aX+sX*5    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPF Delay Time",  synthesizer, channel, VL_PORTAMENTO,    OPFDL, aX         , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPF Attack Time", synthesizer, channel, VL_TEMPO,         OPFAT, aX+sX      , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPF Decay Time",  synthesizer, channel, VL_TEMPO,         OPFDE, aX+sX*2    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPF Sustain Lvl", synthesizer, channel, VL_ZERO_TO_ONE,   OPFSU, aX+sX*3    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPF SustainTime", synthesizer, channel, VL_PORTAMENTO,    OPFST, aX+sX*4    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPF ReleaseTime", synthesizer, channel, VL_TEMPO,         OPFRE, aX+sX*5    , aY+sY   );
+    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10*GUI_SCALE,10*GUI_SCALE,"OPF On/Off",      synthesizer, channel,                   OPFON, aX         , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPF Waveform",    synthesizer, channel, VL_WAVEFORM,      OPFWF, aX+sX2     , aY      );
+    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10*GUI_SCALE,10*GUI_SCALE,"OPF Keyb Track",  synthesizer, channel,                   OPFKT, aX+sX+sX2  , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPF Coarse Tune", synthesizer, channel, VL_COARSE_TUNE,   OPFCT, aX+sX*2    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPF Fine Tune",   synthesizer, channel, VL_FINE_TUNE,     OPFFT, aX+sX*3    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPF VlSensivity", synthesizer, channel, VL_ZERO_TO_ONE,   OPFVS, aX+sX*4    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPF KeybScaling", synthesizer, channel, VL_MINUS1_2_PLUS1,OPFKS, aX+sX*5    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPF Delay Time",  synthesizer, channel, VL_PORTAMENTO,    OPFDL, aX         , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPF Attack Time", synthesizer, channel, VL_TEMPO,         OPFAT, aX+sX      , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPF Decay Time",  synthesizer, channel, VL_TEMPO,         OPFDE, aX+sX*2    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPF Sustain Lvl", synthesizer, channel, VL_ZERO_TO_ONE,   OPFSU, aX+sX*3    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPF SustainTime", synthesizer, channel, VL_PORTAMENTO,    OPFST, aX+sX*4    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPF ReleaseTime", synthesizer, channel, VL_TEMPO,         OPFRE, aX+sX*5    , aY+sY   );
 
     // OPX
     aX = cX;
     aY = cY + oY * 3;
-    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10,10,"OPX On/Off",      synthesizer, channel,                   OPXON, aX         , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPX Cuttof",      synthesizer, channel, VL_FILTER_CUTOFF, OPXCU, aX+sX2     , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPX Resonance",   synthesizer, channel, VL_ZERO_TO_ONE,   OPXRS, aX+sX+sX2  , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPX Amount",      synthesizer, channel, VL_ZERO_TO_ONE,   OPXAM, aX+sX*2+sX2, aY      );
-    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10,10,"OPX Bypass",      synthesizer, channel,                   OPXBP, aX+sX*3+sX2, aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPX VlSensivity", synthesizer, channel, VL_ZERO_TO_ONE,   OPXVS, aX+sX*4    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPX KeybScaling", synthesizer, channel, VL_MINUS1_2_PLUS1,OPXKS, aX+sX*5    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPX Delay Time",  synthesizer, channel, VL_PORTAMENTO,    OPXDL, aX         , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPX Attack Time", synthesizer, channel, VL_TEMPO,         OPXAT, aX+sX      , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPX Decay Time",  synthesizer, channel, VL_TEMPO,         OPXDE, aX+sX*2    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPX Sustain Lvl", synthesizer, channel, VL_ZERO_TO_ONE,   OPXSU, aX+sX*3    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPX SustainTime", synthesizer, channel, VL_PORTAMENTO,    OPXST, aX+sX*4    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPX ReleaseTime", synthesizer, channel, VL_TEMPO,         OPXRE, aX+sX*5    , aY+sY   );
+    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10*GUI_SCALE,10*GUI_SCALE,"OPX On/Off",      synthesizer, channel,                   OPXON, aX         , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPX Cuttof",      synthesizer, channel, VL_FILTER_CUTOFF, OPXCU, aX+sX2     , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPX Resonance",   synthesizer, channel, VL_ZERO_TO_ONE,   OPXRS, aX+sX+sX2  , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPX Amount",      synthesizer, channel, VL_ZERO_TO_ONE,   OPXAM, aX+sX*2+sX2, aY      );
+    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10*GUI_SCALE,10*GUI_SCALE,"OPX Bypass",      synthesizer, channel,                   OPXBP, aX+sX*3+sX2, aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPX VlSensivity", synthesizer, channel, VL_ZERO_TO_ONE,   OPXVS, aX+sX*4    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPX KeybScaling", synthesizer, channel, VL_MINUS1_2_PLUS1,OPXKS, aX+sX*5    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPX Delay Time",  synthesizer, channel, VL_PORTAMENTO,    OPXDL, aX         , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPX Attack Time", synthesizer, channel, VL_TEMPO,         OPXAT, aX+sX      , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPX Decay Time",  synthesizer, channel, VL_TEMPO,         OPXDE, aX+sX*2    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPX Sustain Lvl", synthesizer, channel, VL_ZERO_TO_ONE,   OPXSU, aX+sX*3    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPX SustainTime", synthesizer, channel, VL_PORTAMENTO,    OPXST, aX+sX*4    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPX ReleaseTime", synthesizer, channel, VL_TEMPO,         OPXRE, aX+sX*5    , aY+sY   );
 
     // OPZ
     aX = cX + oX;
     aY = cY + oY * 3;
-    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10,10,"OPZ On/Off",      synthesizer, channel,                   OPZON, aX         , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPZ Cuttof",      synthesizer, channel, VL_FILTER_CUTOFF, OPZCU, aX+sX2     , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPZ Resonance",   synthesizer, channel, VL_ZERO_TO_ONE,   OPZRS, aX+sX+sX2  , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPZ Type",        synthesizer, channel, VL_FILTER,        OPZTY, aX+sX*2+sX2, aY      );
-    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10,10,"OPZ Keyb Track",  synthesizer, channel,                   OPZKT, aX+sX*3+sX2, aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPZ VlSensivity", synthesizer, channel, VL_ZERO_TO_ONE,   OPZVS, aX+sX*4    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPZ KeybScaling", synthesizer, channel, VL_MINUS1_2_PLUS1,OPZKS, aX+sX*5    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPZ Delay Time",  synthesizer, channel, VL_PORTAMENTO,    OPZDL, aX         , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPZ Attack Time", synthesizer, channel, VL_TEMPO,         OPZAT, aX+sX      , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPZ Decay Time",  synthesizer, channel, VL_TEMPO,         OPZDE, aX+sX*2    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPZ Sustain Lvl", synthesizer, channel, VL_ZERO_TO_ONE,   OPZSU, aX+sX*3    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPZ SustainTime", synthesizer, channel, VL_PORTAMENTO,    OPZST, aX+sX*4    , aY+sY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "OPZ ReleaseTime", synthesizer, channel, VL_TEMPO,         OPZRE, aX+sX*5    , aY+sY   );
+    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10*GUI_SCALE,10*GUI_SCALE,"OPZ On/Off",      synthesizer, channel,                   OPZON, aX         , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPZ Cuttof",      synthesizer, channel, VL_FILTER_CUTOFF, OPZCU, aX+sX2     , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPZ Resonance",   synthesizer, channel, VL_ZERO_TO_ONE,   OPZRS, aX+sX+sX2  , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPZ Type",        synthesizer, channel, VL_FILTER,        OPZTY, aX+sX*2+sX2, aY      );
+    ctl[ctlcount++] = new CKey     (BMP_KEY,  0,10*GUI_SCALE,10*GUI_SCALE,"OPZ Keyb Track",  synthesizer, channel,                   OPZKT, aX+sX*3+sX2, aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPZ VlSensivity", synthesizer, channel, VL_ZERO_TO_ONE,   OPZVS, aX+sX*4    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPZ KeybScaling", synthesizer, channel, VL_MINUS1_2_PLUS1,OPZKS, aX+sX*5    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPZ Delay Time",  synthesizer, channel, VL_PORTAMENTO,    OPZDL, aX         , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPZ Attack Time", synthesizer, channel, VL_TEMPO,         OPZAT, aX+sX      , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPZ Decay Time",  synthesizer, channel, VL_TEMPO,         OPZDE, aX+sX*2    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPZ Sustain Lvl", synthesizer, channel, VL_ZERO_TO_ONE,   OPZSU, aX+sX*3    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPZ SustainTime", synthesizer, channel, VL_PORTAMENTO,    OPZST, aX+sX*4    , aY+sY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "OPZ ReleaseTime", synthesizer, channel, VL_TEMPO,         OPZRE, aX+sX*5    , aY+sY   );
 
     // Matriz
     aX = mX;
     aY = mY;
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "OPA Self Mod",    synthesizer, channel, VL_MOD,           MAA,     aX       , aY      );
-    ctl[ctlcount++] = new CKey     (BMP_OPS  ,0,20,20,"OPA On/Off",      synthesizer, channel,                   OPAON,   aX       , aY+fY   );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPA->OPB",     synthesizer, channel, VL_MOD,           MAB,     aX       , aY+fY*2 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPA->OPC",     synthesizer, channel, VL_MOD,           MAC,     aX       , aY+fY*3 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPA->OPD",     synthesizer, channel, VL_MOD,           MAD,     aX       , aY+fY*4 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPA->OPE",     synthesizer, channel, VL_MOD,           MAE,     aX       , aY+fY*5 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPA->OPF",     synthesizer, channel, VL_MOD,           MAF,     aX       , aY+fY*6 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPA->OPX",     synthesizer, channel, VL_MOD,           MAX,     aX       , aY+fY*7 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPA->OPZ",     synthesizer, channel, VL_MOD,           MAZ,     aX       , aY+fY*8 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "OPA Output",      synthesizer, channel, VL_MOD,           MAO,     aX       , aY+fY*9 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB3,  20,   "OPA Pan",         synthesizer, channel, VL_PAN,           MAP,     aX       , aY+fY*10);
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "OPA Self Mod",    synthesizer, channel, VL_MOD,           MAA,     aX       , aY      );
+    ctl[ctlcount++] = new CKey     (BMP_OPS  ,0,20*GUI_SCALE,20*GUI_SCALE,"OPA On/Off",      synthesizer, channel,                   OPAON,   aX       , aY+fY   );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPA->OPB",     synthesizer, channel, VL_MOD,           MAB,     aX       , aY+fY*2 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPA->OPC",     synthesizer, channel, VL_MOD,           MAC,     aX       , aY+fY*3 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPA->OPD",     synthesizer, channel, VL_MOD,           MAD,     aX       , aY+fY*4 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPA->OPE",     synthesizer, channel, VL_MOD,           MAE,     aX       , aY+fY*5 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPA->OPF",     synthesizer, channel, VL_MOD,           MAF,     aX       , aY+fY*6 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPA->OPX",     synthesizer, channel, VL_MOD,           MAX,     aX       , aY+fY*7 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPA->OPZ",     synthesizer, channel, VL_MOD,           MAZ,     aX       , aY+fY*8 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "OPA Output",      synthesizer, channel, VL_MOD,           MAO,     aX       , aY+fY*9 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB3,  20*GUI_SCALE,   "OPA Pan",         synthesizer, channel, VL_PAN,           MAP,     aX       , aY+fY*10);
 
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "OPB Self Mod",    synthesizer, channel, VL_MOD,           MBB,     aX+fX    , aY+fY   );
-    ctl[ctlcount++] = new CKey     (BMP_OPS  ,1,20,20,"OPB On/Off",      synthesizer, channel,                   OPBON,   aX+fX    , aY+fY*2 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPB->OPC",     synthesizer, channel, VL_MOD,           MBC,     aX+fX    , aY+fY*3 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPB->OPD",     synthesizer, channel, VL_MOD,           MBD,     aX+fX    , aY+fY*4 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPB->OPE",     synthesizer, channel, VL_MOD,           MBE,     aX+fX    , aY+fY*5 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPB->OPF",     synthesizer, channel, VL_MOD,           MBF,     aX+fX    , aY+fY*6 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPB->OPX",     synthesizer, channel, VL_MOD,           MBX,     aX+fX    , aY+fY*7 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPB->OPZ",     synthesizer, channel, VL_MOD,           MBZ,     aX+fX    , aY+fY*8 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "OPB Output",      synthesizer, channel, VL_MOD,           MBO,     aX+fX    , aY+fY*9 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB3,  20,   "OPB Pan",         synthesizer, channel, VL_PAN,           MBP,     aX+fX    , aY+fY*10);
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "OPB Self Mod",    synthesizer, channel, VL_MOD,           MBB,     aX+fX    , aY+fY   );
+    ctl[ctlcount++] = new CKey     (BMP_OPS  ,1,20*GUI_SCALE,20*GUI_SCALE,"OPB On/Off",      synthesizer, channel,                   OPBON,   aX+fX    , aY+fY*2 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPB->OPC",     synthesizer, channel, VL_MOD,           MBC,     aX+fX    , aY+fY*3 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPB->OPD",     synthesizer, channel, VL_MOD,           MBD,     aX+fX    , aY+fY*4 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPB->OPE",     synthesizer, channel, VL_MOD,           MBE,     aX+fX    , aY+fY*5 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPB->OPF",     synthesizer, channel, VL_MOD,           MBF,     aX+fX    , aY+fY*6 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPB->OPX",     synthesizer, channel, VL_MOD,           MBX,     aX+fX    , aY+fY*7 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPB->OPZ",     synthesizer, channel, VL_MOD,           MBZ,     aX+fX    , aY+fY*8 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "OPB Output",      synthesizer, channel, VL_MOD,           MBO,     aX+fX    , aY+fY*9 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB3,  20*GUI_SCALE,   "OPB Pan",         synthesizer, channel, VL_PAN,           MBP,     aX+fX    , aY+fY*10);
 
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "OPC Self Mod",    synthesizer, channel, VL_MOD,           MCC,     aX+fX*2  , aY+fY*2 );
-    ctl[ctlcount++] = new CKey     (BMP_OPS  ,2,20,20,"OPC On/Off",      synthesizer, channel,                   OPCON,   aX+fX*2  , aY+fY*3 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPC->OPD",     synthesizer, channel, VL_MOD,           MCD,     aX+fX*2  , aY+fY*4 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPC->OPE",     synthesizer, channel, VL_MOD,           MCE,     aX+fX*2  , aY+fY*5 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPC->OPF",     synthesizer, channel, VL_MOD,           MCF,     aX+fX*2  , aY+fY*6 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPC->OPX",     synthesizer, channel, VL_MOD,           MCX,     aX+fX*2  , aY+fY*7 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPC->OPZ",     synthesizer, channel, VL_MOD,           MCZ,     aX+fX*2  , aY+fY*8 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "OPC Output",      synthesizer, channel, VL_MOD,           MCO,     aX+fX*2  , aY+fY*9 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB3,  20,   "OPC Pan",         synthesizer, channel, VL_PAN,           MCP,     aX+fX*2  , aY+fY*10);
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "OPC Self Mod",    synthesizer, channel, VL_MOD,           MCC,     aX+fX*2  , aY+fY*2 );
+    ctl[ctlcount++] = new CKey     (BMP_OPS  ,2,20*GUI_SCALE,20*GUI_SCALE,"OPC On/Off",      synthesizer, channel,                   OPCON,   aX+fX*2  , aY+fY*3 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPC->OPD",     synthesizer, channel, VL_MOD,           MCD,     aX+fX*2  , aY+fY*4 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPC->OPE",     synthesizer, channel, VL_MOD,           MCE,     aX+fX*2  , aY+fY*5 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPC->OPF",     synthesizer, channel, VL_MOD,           MCF,     aX+fX*2  , aY+fY*6 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPC->OPX",     synthesizer, channel, VL_MOD,           MCX,     aX+fX*2  , aY+fY*7 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPC->OPZ",     synthesizer, channel, VL_MOD,           MCZ,     aX+fX*2  , aY+fY*8 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "OPC Output",      synthesizer, channel, VL_MOD,           MCO,     aX+fX*2  , aY+fY*9 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB3,  20*GUI_SCALE,   "OPC Pan",         synthesizer, channel, VL_PAN,           MCP,     aX+fX*2  , aY+fY*10);
 
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "OPD Self Mod",    synthesizer, channel, VL_MOD,           MDD,     aX+fX*3  , aY+fY*3 );
-    ctl[ctlcount++] = new CKey     (BMP_OPS  ,3,20,20,"OPD On/Off",      synthesizer, channel,                   OPDON,   aX+fX*3  , aY+fY*4 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPD->OPE",     synthesizer, channel, VL_MOD,           MDE,     aX+fX*3  , aY+fY*5 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPD->OPF",     synthesizer, channel, VL_MOD,           MDF,     aX+fX*3  , aY+fY*6 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPD->OPX",     synthesizer, channel, VL_MOD,           MDX,     aX+fX*3  , aY+fY*7 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPD->OPZ",     synthesizer, channel, VL_MOD,           MDZ,     aX+fX*3  , aY+fY*8 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "OPD Output",      synthesizer, channel, VL_MOD,           MDO,     aX+fX*3  , aY+fY*9 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB3,  20,   "OPD Pan",         synthesizer, channel, VL_PAN,           MDP,     aX+fX*3  , aY+fY*10);
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "OPD Self Mod",    synthesizer, channel, VL_MOD,           MDD,     aX+fX*3  , aY+fY*3 );
+    ctl[ctlcount++] = new CKey     (BMP_OPS  ,3,20*GUI_SCALE,20*GUI_SCALE,"OPD On/Off",      synthesizer, channel,                   OPDON,   aX+fX*3  , aY+fY*4 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPD->OPE",     synthesizer, channel, VL_MOD,           MDE,     aX+fX*3  , aY+fY*5 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPD->OPF",     synthesizer, channel, VL_MOD,           MDF,     aX+fX*3  , aY+fY*6 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPD->OPX",     synthesizer, channel, VL_MOD,           MDX,     aX+fX*3  , aY+fY*7 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPD->OPZ",     synthesizer, channel, VL_MOD,           MDZ,     aX+fX*3  , aY+fY*8 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "OPD Output",      synthesizer, channel, VL_MOD,           MDO,     aX+fX*3  , aY+fY*9 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB3,  20*GUI_SCALE,   "OPD Pan",         synthesizer, channel, VL_PAN,           MDP,     aX+fX*3  , aY+fY*10);
 
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "OPE Self Mod",    synthesizer, channel, VL_MOD,           MEE,     aX+fX*4  , aY+fY*4 );
-    ctl[ctlcount++] = new CKey     (BMP_OPS  ,4,20,20,"OPE On/Off",      synthesizer, channel,                   OPEON,   aX+fX*4  , aY+fY*5 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPE->OPF",     synthesizer, channel, VL_MOD,           MEF,     aX+fX*4  , aY+fY*6 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPE->OPX",     synthesizer, channel, VL_MOD,           MEX,     aX+fX*4  , aY+fY*7 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPE->OPZ",     synthesizer, channel, VL_MOD,           MEZ,     aX+fX*4  , aY+fY*8 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "OPE Output",      synthesizer, channel, VL_MOD,           MEO,     aX+fX*4  , aY+fY*9 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB3,  20,   "OPE Pan",         synthesizer, channel, VL_PAN,           MEP,     aX+fX*4  , aY+fY*10);
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "OPE Self Mod",    synthesizer, channel, VL_MOD,           MEE,     aX+fX*4  , aY+fY*4 );
+    ctl[ctlcount++] = new CKey     (BMP_OPS  ,4,20*GUI_SCALE,20*GUI_SCALE,"OPE On/Off",      synthesizer, channel,                   OPEON,   aX+fX*4  , aY+fY*5 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPE->OPF",     synthesizer, channel, VL_MOD,           MEF,     aX+fX*4  , aY+fY*6 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPE->OPX",     synthesizer, channel, VL_MOD,           MEX,     aX+fX*4  , aY+fY*7 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPE->OPZ",     synthesizer, channel, VL_MOD,           MEZ,     aX+fX*4  , aY+fY*8 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "OPE Output",      synthesizer, channel, VL_MOD,           MEO,     aX+fX*4  , aY+fY*9 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB3,  20*GUI_SCALE,   "OPE Pan",         synthesizer, channel, VL_PAN,           MEP,     aX+fX*4  , aY+fY*10);
 
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "OPF Self Mod",    synthesizer, channel, VL_MOD,           MFF,     aX+fX*5  , aY+fY*5 );
-    ctl[ctlcount++] = new CKey     (BMP_OPS  ,5,20,20,"OPF On/Off",      synthesizer, channel,                   OPFON,   aX+fX*5  , aY+fY*6 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPF->OPX",     synthesizer, channel, VL_MOD,           MFX,     aX+fX*5  , aY+fY*7 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPF->OPZ",     synthesizer, channel, VL_MOD,           MFZ,     aX+fX*5  , aY+fY*8 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "OPF Output",      synthesizer, channel, VL_MOD,           MFO,     aX+fX*5  , aY+fY*9 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB3,  20,   "OPF Pan",         synthesizer, channel, VL_PAN,           MFP,     aX+fX*5  , aY+fY*10);
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "OPF Self Mod",    synthesizer, channel, VL_MOD,           MFF,     aX+fX*5  , aY+fY*5 );
+    ctl[ctlcount++] = new CKey     (BMP_OPS  ,5,20*GUI_SCALE,20*GUI_SCALE,"OPF On/Off",      synthesizer, channel,                   OPFON,   aX+fX*5  , aY+fY*6 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPF->OPX",     synthesizer, channel, VL_MOD,           MFX,     aX+fX*5  , aY+fY*7 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPF->OPZ",     synthesizer, channel, VL_MOD,           MFZ,     aX+fX*5  , aY+fY*8 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "OPF Output",      synthesizer, channel, VL_MOD,           MFO,     aX+fX*5  , aY+fY*9 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB3,  20*GUI_SCALE,   "OPF Pan",         synthesizer, channel, VL_PAN,           MFP,     aX+fX*5  , aY+fY*10);
 
-    ctl[ctlcount++] = new CKey     (BMP_OPS  ,6,20,20,"OPX On/Off",      synthesizer, channel,                   OPXON,   aX+fX*6  , aY+fY*7 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "FM OPX->OPZ",     synthesizer, channel, VL_MOD,           MXZ,     aX+fX*6  , aY+fY*8 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "OPX Output",      synthesizer, channel, VL_MOD,           MXO,     aX+fX*6  , aY+fY*9 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB3,  20,   "OPX Pan",         synthesizer, channel, VL_PAN,           MXP,     aX+fX*6  , aY+fY*10);
+    ctl[ctlcount++] = new CKey     (BMP_OPS  ,6,20*GUI_SCALE,20*GUI_SCALE,"OPX On/Off",      synthesizer, channel,                   OPXON,   aX+fX*6  , aY+fY*7 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "FM OPX->OPZ",     synthesizer, channel, VL_MOD,           MXZ,     aX+fX*6  , aY+fY*8 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "OPX Output",      synthesizer, channel, VL_MOD,           MXO,     aX+fX*6  , aY+fY*9 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB3,  20*GUI_SCALE,   "OPX Pan",         synthesizer, channel, VL_PAN,           MXP,     aX+fX*6  , aY+fY*10);
 
-    ctl[ctlcount++] = new CKey     (BMP_OPS  ,7,20,20,"OPZ On/Off",      synthesizer, channel,                   OPZON,   aX+fX*7  , aY+fY*8 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20,   "OPZ Output",      synthesizer, channel, VL_MOD,           MZO,     aX+fX*7  , aY+fY*9 );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB3,  20,   "OPZ Pan",         synthesizer, channel, VL_PAN,           MZP,     aX+fX*7  , aY+fY*10);
+    ctl[ctlcount++] = new CKey     (BMP_OPS  ,7,20*GUI_SCALE,20*GUI_SCALE,"OPZ On/Off",      synthesizer, channel,                   OPZON,   aX+fX*7  , aY+fY*8 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB2,  20*GUI_SCALE,   "OPZ Output",      synthesizer, channel, VL_MOD,           MZO,     aX+fX*7  , aY+fY*9 );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB3,  20*GUI_SCALE,   "OPZ Pan",         synthesizer, channel, VL_PAN,           MZP,     aX+fX*7  , aY+fY*10);
 
     // Pitch
     aX = pX;
     aY = pY;
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "Portamento",      synthesizer, channel, VL_PORTAMENTO,    PORTA, aX         , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "Pitch Curve",     synthesizer, channel, VL_PITCH_CURVE,   PTCCU, aX+sX      , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "PitchCurveTime",  synthesizer, channel, VL_PORTAMENTO,    PTCTI, aX+sX*2    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "Portamento",      synthesizer, channel, VL_PORTAMENTO,    PORTA, aX         , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "Pitch Curve",     synthesizer, channel, VL_PITCH_CURVE,   PTCCU, aX+sX      , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "PitchCurveTime",  synthesizer, channel, VL_PORTAMENTO,    PTCTI, aX+sX*2    , aY      );
 
     // LFO
     aX = lX;
     aY = lY;
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "LFO Waveform",    synthesizer, channel, VL_WAVEFORM,      LFOWF, aX         , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "LFO Rate",        synthesizer, channel, VL_LFO_RATE,      LFORA, aX+sX      , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "LFO Depth",       synthesizer, channel, VL_MOD,           LFODE, aX+sX*2    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "LFO Delay",       synthesizer, channel, VL_PORTAMENTO,    LFODL, aX+sX*3    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "LFO Destination", synthesizer, channel, VL_LFO_DEST,      LFODS, aX+sX*4    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "LFO Waveform",    synthesizer, channel, VL_WAVEFORM,      LFOWF, aX         , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "LFO Rate",        synthesizer, channel, VL_LFO_RATE,      LFORA, aX+sX      , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "LFO Depth",       synthesizer, channel, VL_MOD,           LFODE, aX+sX*2    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "LFO Delay",       synthesizer, channel, VL_PORTAMENTO,    LFODL, aX+sX*3    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "LFO Destination", synthesizer, channel, VL_LFO_DEST,      LFODS, aX+sX*4    , aY      );
 
     // Modulation
     aX = dX;
     aY = dY;
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "Mod Destination", synthesizer, channel, VL_MOD_DEST,      MDLDS, aX         , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "Mod Destination", synthesizer, channel, VL_MOD_DEST,      MDLDS, aX         , aY      );
 
     // Channels
     aX = gX;
@@ -332,22 +332,22 @@ CEditor::CEditor(CSynthesizer *synthesizer)
     // Reverb
     aX = rX;
     aY = rY;
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "Reverb Time",     synthesizer, channel, VL_ZERO_TO_ONE,   REVTI, aX         , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "Reverb Damp",     synthesizer, channel, VL_ZERO_TO_ONE,   REVDA, aX+sX      , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "Reverb Time",     synthesizer, channel, VL_ZERO_TO_ONE,   REVTI, aX         , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "Reverb Damp",     synthesizer, channel, VL_ZERO_TO_ONE,   REVDA, aX+sX      , aY      );
 
     // Delay
     aX = eX;
     aY = eY;
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "Delay Time",      synthesizer, channel, VL_ZERO_TO_ONE,   DLYTI, aX         , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "Delay Feedback",  synthesizer, channel, VL_ZERO_TO_ONE,   DLYFE, aX+sX      , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "Delay LFO Rate",  synthesizer, channel, VL_LFO_RATE,      DLYLF, aX+sX*2    , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "Delay LFO Amt",   synthesizer, channel, VL_ZERO_TO_ONE,   DLYLA, aX+sX*3    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "Delay Time",      synthesizer, channel, VL_ZERO_TO_ONE,   DLYTI, aX         , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "Delay Feedback",  synthesizer, channel, VL_ZERO_TO_ONE,   DLYFE, aX+sX      , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "Delay LFO Rate",  synthesizer, channel, VL_LFO_RATE,      DLYLF, aX+sX*2    , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "Delay LFO Amt",   synthesizer, channel, VL_ZERO_TO_ONE,   DLYLA, aX+sX*3    , aY      );
 
     // Effects
     aX = zX;
     aY = zY;
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "Delay Level",     synthesizer, channel, VL_ZERO_TO_ONE,   DLYLV, aX         , aY      );
-    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25,   "Reverb Level",    synthesizer, channel, VL_ZERO_TO_ONE,   RVBLV, aX+sX      , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "Delay Level",     synthesizer, channel, VL_ZERO_TO_ONE,   DLYLV, aX         , aY      );
+    ctl[ctlcount++] = new CKnob    (BMP_KNOB,   25*GUI_SCALE,   "Reverb Level",    synthesizer, channel, VL_ZERO_TO_ONE,   RVBLV, aX+sX      , aY      );
 
     // Buttons
     aX = bX;
@@ -362,7 +362,7 @@ CEditor::CEditor(CSynthesizer *synthesizer)
     ctl[ctlcount++] = new CButton  (BMP_BUTTONS, 7,                      synthesizer, channel, BT_STORE,                aX+tX*3    , aY+tY   );
 
     // HQ
-    ctl[ctlcount++] = new CKey     (BMP_KEY,0,10,10,"High Quality",      synthesizer, channel,                   HQ   , hX         , hY      );
+    ctl[ctlcount++] = new CKey     (BMP_KEY,0,10*GUI_SCALE,10*GUI_SCALE,"High Quality",      synthesizer, channel,                   HQ   , hX         , hY      );
 
     changingControl = false;
     this->currentX  = -1;

--- a/src/gui/lcd.cpp
+++ b/src/gui/lcd.cpp
@@ -21,10 +21,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "control.h"
 #include "lcd.h"
 
-#define LCD_SEP_H   1  // horizontal space between the LCD characters
-#define LCD_SEP_V   1  // vertical space between the LCD characters
-#define LCD_CHAR_H  7  // char height in pixels
-#define LCD_CHAR_W  5  // char width in pixels
+#define LCD_SEP_H   1*GUI_SCALE  // horizontal space between the LCD characters
+#define LCD_SEP_V   1*GUI_SCALE  // vertical space between the LCD characters
+#define LCD_CHAR_H  7*GUI_SCALE  // char height in pixels
+#define LCD_CHAR_W  5*GUI_SCALE  // char width in pixels
 #define LCD_X       0  // bg left
 #define LCD_Y       0  // bg top
 

--- a/src/synth/constants.h
+++ b/src/synth/constants.h
@@ -55,8 +55,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define TIMER_RESOLUTION_MS 20
 #define BMP_PATH            "skin"
 #define GUI_CONTROLS        189
-#define GUI_WIDTH           633
-#define GUI_HEIGHT          437
+
+#ifndef GUI_SCALE
+#define GUI_SCALE           1
+#endif
+
+#define GUI_WIDTH           (633*GUI_SCALE)
+#define GUI_HEIGHT          (437*GUI_SCALE)
+
 enum
 {
     BMP_CHARS  ,

--- a/src/toolkits/embedresources.cpp
+++ b/src/toolkits/embedresources.cpp
@@ -17,18 +17,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include <stdio.h>
+#include <dirent.h>
 
-#define PATH "skins/default/"
+#define BMP_PATH "skin/"
+#define PATH     "skins/default/"
 
 void append_file(FILE *fout, const char *path, const char *name)
 {
     FILE *f = fopen(path, "rb");
     unsigned char c;
     unsigned int i = 0;
+    size_t n;
     fprintf(fout, "const unsigned char _%s[] = {\n", name);
     while (!feof(f))
     {
-        (void)fread(&c, 1, 1, f);
+        n=fread(&c, 1, 1, f);
         fprintf(fout, "0x%02X%s%s", c, !feof(f) ? "," : "", ++i % 16 ? "" : "\n");
     }
     fprintf(fout, "};\n");
@@ -43,18 +46,36 @@ int main(int argc, char *argv[])
         return 1;
     }
     FILE *f = fopen(argv[1], "wb");
-    if (!f)
+    if (f == NULL)
     {
         return 2;
     }
-    append_file(f, PATH"bg.bmp"     , "bg_bmp"     );
-    append_file(f, PATH"buttons.bmp", "buttons_bmp");
-    append_file(f, PATH"chars.bmp"  , "chars_bmp"  );
-    append_file(f, PATH"key.bmp"    , "key_bmp"    );
-    append_file(f, PATH"knob2.bmp"  , "knob2_bmp"  );
-    append_file(f, PATH"knob3.bmp"  , "knob3_bmp"  );
-    append_file(f, PATH"knob.bmp"   , "knob_bmp"   );
-    append_file(f, PATH"ops.bmp"    , "ops_bmp"    );
+    DIR *dir = opendir(BMP_PATH);
+    if(dir != NULL)
+    {
+        closedir(dir);
+        fprintf(stderr, "Generating %s using %s\n",argv[1],BMP_PATH);
+        append_file(f, BMP_PATH"bg.bmp"     , "bg_bmp"     );
+        append_file(f, BMP_PATH"buttons.bmp", "buttons_bmp");
+        append_file(f, BMP_PATH"chars.bmp"  , "chars_bmp"  );
+        append_file(f, BMP_PATH"key.bmp"    , "key_bmp"    );
+        append_file(f, BMP_PATH"knob2.bmp"  , "knob2_bmp"  );
+        append_file(f, BMP_PATH"knob3.bmp"  , "knob3_bmp"  );
+        append_file(f, BMP_PATH"knob.bmp"   , "knob_bmp"   );
+        append_file(f, BMP_PATH"ops.bmp"    , "ops_bmp"    );
+    }
+    else
+    {
+        fprintf(stderr, "Generating %s using %s\n",argv[1],PATH);
+        append_file(f, PATH"bg.bmp"     , "bg_bmp"     );
+        append_file(f, PATH"buttons.bmp", "buttons_bmp");
+        append_file(f, PATH"chars.bmp"  , "chars_bmp"  );
+        append_file(f, PATH"key.bmp"    , "key_bmp"    );
+        append_file(f, PATH"knob2.bmp"  , "knob2_bmp"  );
+        append_file(f, PATH"knob3.bmp"  , "knob3_bmp"  );
+        append_file(f, PATH"knob.bmp"   , "knob_bmp"   );
+        append_file(f, PATH"ops.bmp"    , "ops_bmp"    );
+    }
     fclose(f);
     return 0;
 }


### PR DESCRIPTION
The UI is great but too small (on my 1600x900@20″). The problem should be even bigger with HiDPI screens. So here is a simple patch that multiply every thing by the constant `GUI_SCALE` defined in `src/synth/constants.h` . Can only be an integer (1, 2, 3, ...), 1 being the actual size 633x437. Of course, you have to scale the images of your theme accordingly. Only tested on xlib but should work with every toolkit. It wasn't difficult to implement thanks to the well-written code that uses variables for positioning the widgets.